### PR TITLE
Reverse motor position and velocity when appropriate

### DIFF
--- a/rev-extensions-2/src/main/java/org/openftc/revextensions2/RevBulkData.java
+++ b/rev-extensions-2/src/main/java/org/openftc/revextensions2/RevBulkData.java
@@ -30,9 +30,13 @@ import com.qualcomm.hardware.lynx.commands.core.LynxGetBulkInputDataResponse;
 import com.qualcomm.robotcore.hardware.AnalogInput;
 import com.qualcomm.robotcore.hardware.AnalogInputController;
 import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.DigitalChannel;
 import com.qualcomm.robotcore.hardware.DigitalChannelController;
 import com.qualcomm.robotcore.hardware.DigitalChannelImpl;
+import com.qualcomm.robotcore.hardware.configuration.MotorConfigurationType;
+
+import org.firstinspires.ftc.robotcore.external.navigation.Rotation;
 
 import java.lang.reflect.Field;
 
@@ -52,6 +56,13 @@ public class RevBulkData
         this.module = module;
     }
 
+    // see DcMotorImpl#getOperationalDirection()
+    private static DcMotorSimple.Direction getMotorOperationalDirection(DcMotor dcMotor) {
+        MotorConfigurationType motorType = dcMotor.getMotorType();
+        DcMotorSimple.Direction direction = dcMotor.getDirection();
+        return motorType.getOrientation() == Rotation.CCW ? direction.inverted() : direction;
+    }
+
     public int getMotorCurrentPosition(int motorNum)
     {
         return response.getEncoder(motorNum);
@@ -60,7 +71,15 @@ public class RevBulkData
     public int getMotorCurrentPosition(DcMotor motor)
     {
         validateMotor(motor);
-        return getMotorCurrentPosition(motor.getPortNumber());
+        int position = getMotorCurrentPosition(motor.getPortNumber());
+        if (getMotorOperationalDirection(motor) == DcMotorSimple.Direction.REVERSE)
+        {
+            return -position;
+        }
+        else
+        {
+            return position;
+        }
     }
 
     public int getMotorVelocity(int motorNum)
@@ -71,7 +90,15 @@ public class RevBulkData
     public int getMotorVelocity(DcMotor motor)
     {
         validateMotor(motor);
-        return getMotorVelocity(motor.getPortNumber());
+        int velocity = getMotorVelocity(motor.getPortNumber());
+        if (getMotorOperationalDirection(motor) == DcMotorSimple.Direction.REVERSE)
+        {
+            return -velocity;
+        }
+        else
+        {
+            return velocity;
+        }
     }
 
     public boolean isMotorAtTargetPosition(int motorNum)


### PR DESCRIPTION
`RevBulkData` position and velocity data accessions always return the raw data. This behavior is consistent with controller-based interactions but not motor-based interactions. This PR modifies the `DcMotor` argument versions of `RevBulkData.getMotorCurrentPosition()` and `RevBulkData.getMotorVelocity()` to maintain consistency with `DcMotor.getMotorCurrentPosition()` and `DcMotorEx.getVelocity()`, respectively.